### PR TITLE
Add a delimiter to a prompt that doesn't have a default

### DIFF
--- a/lib/Term/UI.pm
+++ b/lib/Term/UI.pm
@@ -266,9 +266,14 @@ sub _tt_readline {
     history( $print_me ) if $print_me;
 
 
-    ### we might have to add a default value to the prompt, to
-    ### show the user what will be picked by default:
-    $prompt .= " [$prompt_add]: " if $prompt_add;
+    if ($prompt_add) {
+        ### we might have to add a default value to the prompt, to
+        ### show the user what will be picked by default:
+        $prompt .= " [$prompt_add]: " ;
+    }
+    else {
+        $prompt .= " : ";
+    }
 
 
     ### are we in autoreply mode?


### PR DESCRIPTION
Present behavior is that there is only a delimiter (a colon with spacing) when the `default` option is specified:

```
$ perl -Ilib -MTerm::ReadLine -MTerm::UI \
-e '$term = Term::ReadLine->new("foobar");' \
-e '$term->get_reply(' \
-e '    prompt  => "Choose one",' \
-e '    choices => [qw(red blue green)],' \
-e '    default => "blue"' \
-e ');'

  1> red
  2> blue
  3> green

Choose one [2]: 3
$ perl -Ilib -MTerm::ReadLine -MTerm::UI \
-e '$term = Term::ReadLine->new("foobar");' \
-e '$term->get_reply(' \
-e '    prompt  => "Choose one",' \
-e '    choices => [qw(red blue green)],' \
-e ');'

  1> red
  2> blue
  3> green

Choose one3
```

Commit 1e02d71 makes the case without the `default` option produce this output:

```
  1> red
  2> blue
  3> green

Choose one : 3
```
