### PR TITLE
add notice of removal from perl core

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,7 @@ WriteMakefile (
     VERSION_FROM    => 'lib/Term/UI.pm', # finds $VERSION
     dist            => { COMPRESS => 'gzip -9f', SUFFIX => 'gz' },
     PREREQ_PM       => {
+                        'if'                        => 0,
                         'Test::More'                => 0,
                         'Params::Check'             => 0,
                         'Term::ReadLine'            => 0,

--- a/lib/Term/UI.pm
+++ b/lib/Term/UI.pm
@@ -1,5 +1,7 @@
 package Term::UI;
 
+use if $] > 5.017, 'deprecate';
+
 use Carp;
 use Params::Check qw[check allow];
 use Term::ReadLine;


### PR DESCRIPTION
...this PR will also fix the install destination on perls 5.12 and later.
