### PR TITLE
fix multi-choice without defaults

### DIFF
--- a/lib/Term/UI.pm
+++ b/lib/Term/UI.pm
@@ -134,7 +134,7 @@ sub get_reply {
                 or ( carp( loc(q[Could not parse arguments]) ), return );
 
     # Check for legacy default on multi=1
-    if ($args->{multi} and ref($args->{default}) ne "ARRAY") {
+    if ($args->{multi} and defined $args->{default} and ref($args->{default}) ne "ARRAY") {
         $args->{default} = [ $args->{default} ];
     }
 
@@ -166,7 +166,7 @@ sub get_reply {
             $args->{print_me} .= sprintf "\n%3s> %-s", $i, $choice;
         }
 
-        $prompt_add = join(" ", @$prompt_add) if ($args->{multi});
+        $prompt_add = join(" ", @$prompt_add) if ( $prompt_add && $args->{multi} );
 
         ### we listed some choices -- add another newline for
         ### pretty printing

--- a/t/02_ui.t
+++ b/t/02_ui.t
@@ -2,7 +2,7 @@
 
 use strict;
 use lib qw[../lib lib];
-use Test::More tests => 21;
+use Test::More tests => 22;
 use Term::ReadLine;
 
 use_ok( 'Term::UI' );
@@ -50,6 +50,15 @@ my $tmpl = {
     delete $args->{choices};
 
     is( $term->get_reply( %$args ), 'blue', q[Checking reply with defaults] );
+}
+
+{
+    my $args = \%{ $tmpl };
+    $args->{choices} = [qw|blue red green|],
+    $args->{multi} = 1;
+    delete $args->{default};
+
+    is_deeply( [ $term->get_reply( %$args ) ], [undef], q[Checking reply with multiple choices but no defaults] );
 }
 
 {


### PR DESCRIPTION
Fix handling of multiple-choice questions without defaults, so it works as described in documentation rather than crashing.