### PR TITLE
Fix breakage by incorrect regex in 'choices'

### DIFF
--- a/lib/Term/UI.pm
+++ b/lib/Term/UI.pm
@@ -155,7 +155,7 @@ sub get_reply {
             ### so we can construct a "foo? [DIGIT]" type prompt
             if (defined $args->{default}) {
                 if ($args->{multi}) {
-                    push @$prompt_add, $i if (scalar(grep { m/^$choice$/ } @{$args->{default}}));
+                    push @$prompt_add, $i if grep { $_ eq $choice } @{ $args->{ 'default' } };
                 }
                 else {
                     $prompt_add = $i if ($choice eq $args->{default});

--- a/t/02_ui.t
+++ b/t/02_ui.t
@@ -2,7 +2,7 @@
 
 use strict;
 use lib qw[../lib lib];
-use Test::More tests => 22;
+use Test::More tests => 23;
 use Term::ReadLine;
 
 use_ok( 'Term::UI' );
@@ -78,6 +78,20 @@ my $tmpl = {
 
     is_deeply( [ $term->get_reply( %$args ) ], [qw|blue red|], q[Checking reply with multible defaults] );
 }
+
+{
+  my $args =
+    { 'prompt' => "What is your favourite colour?",
+      'choices' => [ qw| blue red green [ | ],
+      'multi' => 1,
+      'default' => [ qw| blue red | ],
+    };
+
+  is_deeply( [ $term->get_reply( %$args ) ], [ qw| blue red | ],
+             q[Checking reply with multible defaults and choices (including a broken regex)],
+           );
+}
+
 
 {
     my $args = {


### PR DESCRIPTION
Addresses #134899

If 'choices' includes an incorrect regex (e.g. '['), 'multi' is 1 and 'default' is provided that'll lead to a fatal error.
This fixes such case.