### PR TITLE
Fix selecting the last choice by its number

### DIFF
--- a/lib/Term/UI.pm
+++ b/lib/Term/UI.pm
@@ -397,7 +397,7 @@ sub _tt_readline {
                 ### a non-digit is an open answer
                 if ( $answer =~ /\D/
                      || ( $answer =~ /^\d+$/
-                          && @$choices <= $answer
+                          && @$choices < $answer
                         )
                    ) {
                     push @rv, $answer if allow( $answer, $allow );


### PR DESCRIPTION
If there are few choices, the last one can only be picked by the actual choice, but not its number.
This fixes it.  Not testable with current tests setup...